### PR TITLE
Geocoding addresses

### DIFF
--- a/lib/notebooks/geocode.ipynb
+++ b/lib/notebooks/geocode.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Geocoding Addresses\n",
+    "## This notebook contains code to retrieve addresses from the articles dataframe and send them to Google's Geocoding service to receive lat/long coordinates for locating in a mapping service."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load articles data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Allows us to import packages that exist one level up in the file system\n",
+    "# See https://stackoverflow.com/questions/34478398\n",
+    "import os\n",
+    "import sys\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path = [module_path] + sys.path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from tagnews.utils import load_data as ld\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df = ld.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Count all the articles with addressses transcribed from the articles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "addr_list = df.locations[df.locations.apply(len) > 0].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "len(addr_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Count the total number of addresses transcribed from the articles to be geocoded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "count = 0\n",
+    "for i in addr_list:\n",
+    "    if 'lat_long' not in i[0].keys():\n",
+    "        count += len(i)\n",
+    "print(count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run following 2 lines if making changes to lat_long.py. They allow this notebook to automatically update those changes for testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  Please also note that you will need to supply an api_key from Google's Geocoding API site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import lat_long as ll\n",
+    "api_key = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Main program to gather available locations data that does not yet have lat/long coordinates. \n",
+    "### Set `test = True` to run smaller batches to prevent reaching Google's query limits too quickly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "latlong_data = ll.get_lat_long(df, test=False, api_key = api_key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "latlong_data[312]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Can see from running code block below that some of the queries didn't return results for a variety of reasons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "count = 0\n",
+    "no_results = []\n",
+    "for i in latlong_data:\n",
+    "    for j in i:\n",
+    "        if 'lat_long' not in j.keys():\n",
+    "            count += 1\n",
+    "            no_results.append(j)\n",
+    "print('Number of addresses that didn\\'t recieve lat/log coords: {}.'.format(count))\n",
+    "no_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Code block below can be run to see how the query works. You will need to supply your own api_key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from geopy.geocoders import GoogleV3\n",
+    "api_key = ''\n",
+    "g = GoogleV3(api_key = api_key, timeout = 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "addr_list[100][3]['cleaned text']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "addr = addr_list[0][2]['cleaned text']\n",
+    "location = g.geocode(addr, components={'locality':'Chicago'})\n",
+    "location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/lib/notebooks/lat_long.py
+++ b/lib/notebooks/lat_long.py
@@ -1,0 +1,97 @@
+from geopy.geocoders import GoogleV3
+import time
+import progressbar
+import random
+
+def get_loc_list(dframe, test=False):
+    ''' Search through dframe and collect articles that don't yet have lat/long coordinates. Only return articles
+        with total number of addresses less than or equal to 2500. If test is True only return 60 articles. '''
+    
+    # Slice all lists from dframe.locations that have locations data
+    
+    ll_list = list(dframe.locations[dframe.locations.apply(len) > 0].values)
+    
+    count1 = 0
+    count2 = 0
+    count3 = 0
+    count4 = 0
+    count5 = 0
+    
+    if test:
+        total = 30
+    else:
+        total = 2500
+        
+    ll_list_2 = []
+    for i in ll_list:
+        if count2 < total:
+            if 'lat_long' not in i[0].keys():
+                ll_list_2.append(i)
+                count1 += len(i)
+                count2 += 1
+   #     count5 += 1
+   # 
+   # print(len(ll_list), count3, count4, count5)
+   # print('List has {} articles and {} addresses.'.format(count2, count1))
+   # 
+   # count = 0
+   # for i in ll_list:
+   #     count += len(i)
+   # print('For test mode, {} articles with {} addresses will be processed.'.format(len(ll_list),count))
+   # 
+    return ll_list_2
+
+def get_lat_long(dframe, test=False, api_key):
+    ''' Find all addresses associated with each news article in the dataframe and return the list of dictionaries
+        for the address info with the lat/long coords added as a key/value pair to it's associated dict. '''
+    
+    g = GoogleV3(api_key = api_key, timeout = 10)
+    
+    loc_list = get_loc_list(dframe, test=test)
+    
+    test_batch = 30  # For debug
+    batch1 = 50      # Google's geocoder service per second rate limit is 50 qps
+    batch2 = 2500    # Google's geocoder service daily rate limit is 2500 qpd
+    
+    count = 0
+    for i in loc_list:
+        count += len(i)
+    
+    count1 = 0       # batch1 counter
+    count2 = 0       # batch2 counter
+    location = []
+    
+    if test:
+        #loc_list_batch = loc_list[:test_batch]
+        count = 0
+        for i in loc_list:
+            count += len(i)
+        print('For test mode, {} articles with {} addresses will be processed.'.format(len(loc_list),count))
+        max_value = test_batch
+    elif count < batch2:
+        print('{} articles with {} addresses will be processed.'.format(len(loc_list),count))
+        max_value = count
+    else:
+        count = 0
+        for i in loc_list:
+            count += len(i)
+        print('{} articles with {} addresses will be processed.'.format(len(loc_list),count))
+        max_value = batch2
+        
+    with progressbar.ProgressBar(max_value=max_value) as bar:
+        for i,l in enumerate(loc_list):
+            for j,m in enumerate(l):
+                if count1 >= batch1:
+                    count1 = 0
+                    time.sleep(0.5)
+                    #break
+                else:
+                    addr = m.get('cleaned text').rstrip('?,.:; ')
+                    location = g.geocode(addr, components={'locality':'Chicago'})
+                    loc_list[i][j]['lat_long'] = location
+                    count1 += 1
+            count2 += 1
+            time.sleep(0.01)
+            bar.update(count2)
+                
+    return loc_list


### PR DESCRIPTION
lat_long.py is a script that finds addresses in the articles dataframe that don't yet have lat/long coordinates, submits those addresses to Google's Geocoding service and returns those results.

geocode.ipynb is a notebook that looks the articles dataframe, runs the script, and helps analyze the results.

Submitted for issue #23 